### PR TITLE
feat: Contentful Post Card Integration with ContentGrid Support

### DIFF
--- a/src/__tests__/components/global/hero.test.tsx
+++ b/src/__tests__/components/global/hero.test.tsx
@@ -120,8 +120,8 @@ describe('Hero Component', () => {
 
     // Check title classes
     const titleElement = screen.getByText('Test Hero Title');
-    expect(titleElement).toHaveClass('text-4xl');
-    expect(titleElement).toHaveClass('sm:text-5xl');
+    expect(titleElement).toHaveClass('text-headline-md');
+    expect(titleElement).toHaveClass('sm:text-headline-lg');
 
     // Check description classes
     const descriptionElement = screen.getByText('Test hero description text');

--- a/src/__tests__/lib/contentful-api/post.test.ts
+++ b/src/__tests__/lib/contentful-api/post.test.ts
@@ -214,9 +214,7 @@ describe('Post API Module', () => {
       });
 
       await expect(postAPI.getAllPosts()).rejects.toThrow(ContentfulError);
-      await expect(postAPI.getAllPosts()).rejects.toThrow(
-        'Failed to fetch Posts from Contentful'
-      );
+      await expect(postAPI.getAllPosts()).rejects.toThrow('Failed to fetch Posts from Contentful');
     });
 
     it('passes through ContentfulError when thrown by fetchGraphQL', async () => {
@@ -234,9 +232,7 @@ describe('Post API Module', () => {
       (fetchGraphQL as any).mockRejectedValue(error);
 
       await expect(postAPI.getAllPosts()).rejects.toThrow(NetworkError);
-      await expect(postAPI.getAllPosts()).rejects.toThrow(
-        'Error fetching Posts: Network failure'
-      );
+      await expect(postAPI.getAllPosts()).rejects.toThrow('Error fetching Posts: Network failure');
     });
 
     it('handles unknown errors', async () => {
@@ -463,7 +459,9 @@ describe('Post API Module', () => {
       (fetchGraphQL as any).mockRejectedValue(error);
 
       await expect(postAPI.getPostBySlug('test-slug')).rejects.toThrow(ContentfulError);
-      await expect(postAPI.getPostBySlug('test-slug')).rejects.toThrow('Test error from fetchGraphQL');
+      await expect(postAPI.getPostBySlug('test-slug')).rejects.toThrow(
+        'Test error from fetchGraphQL'
+      );
     });
 
     it('wraps Error in NetworkError when thrown by fetchGraphQL', async () => {
@@ -481,7 +479,9 @@ describe('Post API Module', () => {
       // Mock unknown error
       (fetchGraphQL as any).mockRejectedValue('Unknown error');
 
-      await expect(postAPI.getPostBySlug('test-slug')).rejects.toThrow('Unknown error fetching Post by slug');
+      await expect(postAPI.getPostBySlug('test-slug')).rejects.toThrow(
+        'Unknown error fetching Post by slug'
+      );
     });
   });
 
@@ -587,7 +587,9 @@ describe('Post API Module', () => {
       (fetchGraphQL as any).mockRejectedValue(error);
 
       await expect(postAPI.getPostsByCategory('Blog')).rejects.toThrow(ContentfulError);
-      await expect(postAPI.getPostsByCategory('Blog')).rejects.toThrow('Test error from fetchGraphQL');
+      await expect(postAPI.getPostsByCategory('Blog')).rejects.toThrow(
+        'Test error from fetchGraphQL'
+      );
     });
 
     it('wraps Error in NetworkError when thrown by fetchGraphQL', async () => {
@@ -605,7 +607,9 @@ describe('Post API Module', () => {
       // Mock unknown error
       (fetchGraphQL as any).mockRejectedValue('Unknown error');
 
-      await expect(postAPI.getPostsByCategory('Blog')).rejects.toThrow('Unknown error fetching Posts by category');
+      await expect(postAPI.getPostsByCategory('Blog')).rejects.toThrow(
+        'Unknown error fetching Posts by category'
+      );
     });
   });
 });

--- a/src/__tests__/lib/contentful-api/post.test.ts
+++ b/src/__tests__/lib/contentful-api/post.test.ts
@@ -1,0 +1,611 @@
+/**
+ * Post API Module Tests
+ *
+ * This test suite verifies the functionality of the Post API module which handles
+ * interactions with Contentful's GraphQL API for Post content type. It tests
+ * the functions that retrieve Post content from Contentful and ensures they
+ * handle error cases appropriately.
+ *
+ * Key aspects tested:
+ * - Fetching all Posts
+ * - Fetching a single Post by ID
+ * - Fetching a single Post by slug
+ * - Fetching Posts by category
+ * - Handling of GraphQL errors
+ * - Handling of empty responses
+ * - Proper parameter passing to the GraphQL API
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as postAPI from '@/lib/contentful-api/post';
+import { fetchGraphQL } from '@/lib/api';
+import { ContentfulError, NetworkError } from '@/lib/errors';
+import type { Post } from '@/types/contentful/Post';
+
+// Mock the fetchGraphQL function
+vi.mock('@/lib/api', () => ({
+  fetchGraphQL: vi.fn()
+}));
+
+// Sample test data
+const mockPosts: Post[] = [
+  {
+    sys: { id: 'post1' },
+    title: 'Test Post 1',
+    slug: 'test-post-1',
+    excerpt: 'This is a test post excerpt',
+    datePublished: '2024-01-15',
+    mainImage: {
+      sys: { id: 'image1' },
+      internalName: 'Test Image 1',
+      link: 'https://example.com/images/test1.jpg',
+      altText: 'Test image 1 description',
+      __typename: 'Image'
+    },
+    content: {
+      nodeType: 'document',
+      data: {},
+      content: [
+        {
+          nodeType: 'paragraph',
+          content: [
+            {
+              nodeType: 'text',
+              value: 'This is test content'
+            }
+          ]
+        }
+      ]
+    },
+    authors: [
+      {
+        sys: { id: 'author1' },
+        name: 'John Doe',
+        title: 'Senior Developer',
+        bio: 'Experienced developer',
+        __typename: 'TeamMember'
+      }
+    ],
+    categories: ['Blog', 'Featured'],
+    tags: ['technology', 'development'],
+    openGraphImage: {
+      sys: { id: 'image2' },
+      internalName: 'OG Image',
+      link: 'https://example.com/images/og.jpg',
+      altText: 'Open graph image',
+      __typename: 'Image'
+    },
+    seoTitle: 'Test Post 1 - SEO Title',
+    seoDescription: 'This is the SEO description for test post 1',
+    seoFocusKeyword: 'test post',
+    __typename: 'Post'
+  },
+  {
+    sys: { id: 'post2' },
+    title: 'Test Post 2',
+    slug: 'test-post-2',
+    excerpt: 'This is another test post excerpt',
+    datePublished: '2024-01-10',
+    content: {
+      nodeType: 'document',
+      data: {},
+      content: [
+        {
+          nodeType: 'paragraph',
+          content: [
+            {
+              nodeType: 'text',
+              value: 'This is more test content'
+            }
+          ]
+        }
+      ]
+    },
+    authors: [
+      {
+        sys: { id: 'author2' },
+        name: 'Jane Smith',
+        title: 'Content Writer',
+        bio: 'Professional writer',
+        __typename: 'TeamMember'
+      }
+    ],
+    categories: ['Case Study'],
+    tags: ['business', 'strategy'],
+    seoTitle: 'Test Post 2 - SEO Title',
+    seoDescription: 'This is the SEO description for test post 2',
+    __typename: 'Post'
+  }
+];
+
+describe('Post API Module', () => {
+  /**
+   * Set up mocks before each test
+   */
+  beforeEach(() => {
+    // Reset all mocks before each test
+    vi.resetAllMocks();
+  });
+
+  /**
+   * Clean up mocks after each test
+   */
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  /**
+   * Tests for getAllPosts function
+   *
+   * Verifies that the function correctly fetches post content from Contentful,
+   * and processes the response structure according to Contentful's GraphQL API conventions.
+   */
+  describe('getAllPosts', () => {
+    it('fetches posts with correct query and parameters', async () => {
+      // Mock successful response with posts
+      const mockPostsResponse = {
+        data: {
+          postCollection: {
+            items: mockPosts
+          }
+        }
+      };
+
+      (fetchGraphQL as any).mockResolvedValue(mockPostsResponse);
+
+      const result = await postAPI.getAllPosts();
+
+      // Verify the result
+      expect(result?.items).toHaveLength(2);
+      expect(result?.items?.[0]?.title).toBe('Test Post 1');
+      expect(result?.items?.[1]?.title).toBe('Test Post 2');
+
+      // Verify fetchGraphQL was called with correct query and parameters
+      expect(fetchGraphQL).toHaveBeenCalledWith(
+        expect.stringContaining('postCollection'),
+        { preview: false },
+        false
+      );
+
+      // Verify the query includes ordering by datePublished_DESC
+      expect(fetchGraphQL).toHaveBeenCalledWith(
+        expect.stringContaining('order: datePublished_DESC'),
+        { preview: false },
+        false
+      );
+    });
+
+    it('uses preview token when preview is true', async () => {
+      // Mock successful response with posts
+      const mockPostsResponse = {
+        data: {
+          postCollection: {
+            items: mockPosts
+          }
+        }
+      };
+
+      (fetchGraphQL as any).mockResolvedValue(mockPostsResponse);
+
+      await postAPI.getAllPosts(true);
+
+      // Verify fetchGraphQL was called with preview parameter
+      expect(fetchGraphQL).toHaveBeenCalledWith(expect.any(String), { preview: true }, true);
+    });
+
+    it('throws ContentfulError when response is invalid', async () => {
+      // Mock invalid response
+      (fetchGraphQL as any).mockResolvedValue({
+        data: null
+      });
+
+      await expect(postAPI.getAllPosts()).rejects.toThrow(ContentfulError);
+      await expect(postAPI.getAllPosts()).rejects.toThrow('Invalid response from Contentful');
+    });
+
+    it('throws ContentfulError when response data structure is invalid', async () => {
+      // Mock response with invalid data structure
+      (fetchGraphQL as any).mockResolvedValue({
+        data: {
+          postCollection: {
+            items: []
+          }
+        }
+      });
+
+      await expect(postAPI.getAllPosts()).rejects.toThrow(ContentfulError);
+      await expect(postAPI.getAllPosts()).rejects.toThrow(
+        'Failed to fetch Posts from Contentful'
+      );
+    });
+
+    it('passes through ContentfulError when thrown by fetchGraphQL', async () => {
+      // Mock ContentfulError from fetchGraphQL
+      const error = new ContentfulError('Test error from fetchGraphQL');
+      (fetchGraphQL as any).mockRejectedValue(error);
+
+      await expect(postAPI.getAllPosts()).rejects.toThrow(ContentfulError);
+      await expect(postAPI.getAllPosts()).rejects.toThrow('Test error from fetchGraphQL');
+    });
+
+    it('wraps Error in NetworkError when thrown by fetchGraphQL', async () => {
+      // Mock standard Error from fetchGraphQL
+      const error = new Error('Network failure');
+      (fetchGraphQL as any).mockRejectedValue(error);
+
+      await expect(postAPI.getAllPosts()).rejects.toThrow(NetworkError);
+      await expect(postAPI.getAllPosts()).rejects.toThrow(
+        'Error fetching Posts: Network failure'
+      );
+    });
+
+    it('handles unknown errors', async () => {
+      // Mock unknown error
+      (fetchGraphQL as any).mockRejectedValue('Unknown error');
+
+      await expect(postAPI.getAllPosts()).rejects.toThrow('Unknown error fetching Posts');
+    });
+  });
+
+  /**
+   * Tests for getPostById function
+   *
+   * Ensures the function correctly fetches a single post by ID,
+   * properly constructs the GraphQL query with the post ID parameter,
+   * and handles cases where the post is not found.
+   */
+  describe('getPostById', () => {
+    it('fetches a single post by ID', async () => {
+      const postId = 'post1';
+
+      // Mock successful response with a post
+      const mockPostResponse = {
+        data: {
+          post: mockPosts[0]
+        }
+      };
+
+      (fetchGraphQL as any).mockResolvedValue(mockPostResponse);
+
+      const result = await postAPI.getPostById(postId);
+
+      // Verify the result
+      expect(result).not.toBeNull();
+      expect(result?.sys?.id).toBe(postId);
+      expect(result?.title).toBe('Test Post 1');
+      expect(result?.slug).toBe('test-post-1');
+
+      // Verify fetchGraphQL was called with correct query and variables
+      expect(fetchGraphQL).toHaveBeenCalledWith(
+        expect.stringContaining('GetPostById'),
+        { id: postId, preview: false },
+        false
+      );
+    });
+
+    it('returns null when post is not found', async () => {
+      // Mock response with no post
+      const mockEmptyResponse = {
+        data: {
+          post: null
+        }
+      };
+
+      (fetchGraphQL as any).mockResolvedValue(mockEmptyResponse);
+
+      const result = await postAPI.getPostById('non-existent-id');
+
+      expect(result).toBeNull();
+    });
+
+    it('uses preview token when preview is true', async () => {
+      const postId = 'post1';
+
+      // Mock successful response
+      const mockPostResponse = {
+        data: {
+          post: mockPosts[0]
+        }
+      };
+
+      (fetchGraphQL as any).mockResolvedValue(mockPostResponse);
+
+      await postAPI.getPostById(postId, true);
+
+      // Verify fetchGraphQL was called with preview parameter
+      expect(fetchGraphQL).toHaveBeenCalledWith(
+        expect.any(String),
+        { id: postId, preview: true },
+        true
+      );
+    });
+
+    it('throws ContentfulError when response is invalid', async () => {
+      // Mock invalid response
+      (fetchGraphQL as any).mockResolvedValue({
+        data: null
+      });
+
+      await expect(postAPI.getPostById('post1')).rejects.toThrow(ContentfulError);
+      await expect(postAPI.getPostById('post1')).rejects.toThrow(
+        'Invalid response from Contentful'
+      );
+    });
+
+    it('passes through ContentfulError when thrown by fetchGraphQL', async () => {
+      // Mock ContentfulError from fetchGraphQL
+      const error = new ContentfulError('Test error from fetchGraphQL');
+      (fetchGraphQL as any).mockRejectedValue(error);
+
+      await expect(postAPI.getPostById('post1')).rejects.toThrow(ContentfulError);
+      await expect(postAPI.getPostById('post1')).rejects.toThrow('Test error from fetchGraphQL');
+    });
+
+    it('wraps Error in NetworkError when thrown by fetchGraphQL', async () => {
+      // Mock standard Error from fetchGraphQL
+      const error = new Error('Network failure');
+      (fetchGraphQL as any).mockRejectedValue(error);
+
+      await expect(postAPI.getPostById('post1')).rejects.toThrow(NetworkError);
+      await expect(postAPI.getPostById('post1')).rejects.toThrow(
+        'Error fetching Post: Network failure'
+      );
+    });
+
+    it('handles unknown errors', async () => {
+      // Mock unknown error
+      (fetchGraphQL as any).mockRejectedValue('Unknown error');
+
+      await expect(postAPI.getPostById('post1')).rejects.toThrow('Unknown error fetching Post');
+    });
+  });
+
+  /**
+   * Tests for getPostBySlug function
+   *
+   * Ensures the function correctly fetches a single post by slug,
+   * properly constructs the GraphQL query with the post slug parameter,
+   * and handles cases where the post is not found.
+   */
+  describe('getPostBySlug', () => {
+    it('fetches a single post by slug', async () => {
+      const postSlug = 'test-post-1';
+
+      // Mock successful response with a post
+      const mockPostResponse = {
+        data: {
+          postCollection: {
+            items: [mockPosts[0]]
+          }
+        }
+      };
+
+      (fetchGraphQL as any).mockResolvedValue(mockPostResponse);
+
+      const result = await postAPI.getPostBySlug(postSlug);
+
+      // Verify the result
+      expect(result).not.toBeNull();
+      expect(result?.slug).toBe(postSlug);
+      expect(result?.title).toBe('Test Post 1');
+
+      // Verify fetchGraphQL was called with correct query and variables
+      expect(fetchGraphQL).toHaveBeenCalledWith(
+        expect.stringContaining('GetPostBySlug'),
+        { slug: postSlug, preview: false },
+        false
+      );
+
+      // Verify the query includes slug filter
+      expect(fetchGraphQL).toHaveBeenCalledWith(
+        expect.stringContaining('where: { slug: $slug }'),
+        { slug: postSlug, preview: false },
+        false
+      );
+    });
+
+    it('returns null when post is not found', async () => {
+      // Mock response with no posts
+      const mockEmptyResponse = {
+        data: {
+          postCollection: {
+            items: []
+          }
+        }
+      };
+
+      (fetchGraphQL as any).mockResolvedValue(mockEmptyResponse);
+
+      const result = await postAPI.getPostBySlug('non-existent-slug');
+
+      expect(result).toBeNull();
+    });
+
+    it('uses preview token when preview is true', async () => {
+      const postSlug = 'test-post-1';
+
+      // Mock successful response
+      const mockPostResponse = {
+        data: {
+          postCollection: {
+            items: [mockPosts[0]]
+          }
+        }
+      };
+
+      (fetchGraphQL as any).mockResolvedValue(mockPostResponse);
+
+      await postAPI.getPostBySlug(postSlug, true);
+
+      // Verify fetchGraphQL was called with preview parameter
+      expect(fetchGraphQL).toHaveBeenCalledWith(
+        expect.any(String),
+        { slug: postSlug, preview: true },
+        true
+      );
+    });
+
+    it('throws ContentfulError when response is invalid', async () => {
+      // Mock invalid response
+      (fetchGraphQL as any).mockResolvedValue({
+        data: null
+      });
+
+      await expect(postAPI.getPostBySlug('test-slug')).rejects.toThrow(ContentfulError);
+      await expect(postAPI.getPostBySlug('test-slug')).rejects.toThrow(
+        'Invalid response from Contentful'
+      );
+    });
+
+    it('passes through ContentfulError when thrown by fetchGraphQL', async () => {
+      // Mock ContentfulError from fetchGraphQL
+      const error = new ContentfulError('Test error from fetchGraphQL');
+      (fetchGraphQL as any).mockRejectedValue(error);
+
+      await expect(postAPI.getPostBySlug('test-slug')).rejects.toThrow(ContentfulError);
+      await expect(postAPI.getPostBySlug('test-slug')).rejects.toThrow('Test error from fetchGraphQL');
+    });
+
+    it('wraps Error in NetworkError when thrown by fetchGraphQL', async () => {
+      // Mock standard Error from fetchGraphQL
+      const error = new Error('Network failure');
+      (fetchGraphQL as any).mockRejectedValue(error);
+
+      await expect(postAPI.getPostBySlug('test-slug')).rejects.toThrow(NetworkError);
+      await expect(postAPI.getPostBySlug('test-slug')).rejects.toThrow(
+        'Error fetching Post by slug: Network failure'
+      );
+    });
+
+    it('handles unknown errors', async () => {
+      // Mock unknown error
+      (fetchGraphQL as any).mockRejectedValue('Unknown error');
+
+      await expect(postAPI.getPostBySlug('test-slug')).rejects.toThrow('Unknown error fetching Post by slug');
+    });
+  });
+
+  /**
+   * Tests for getPostsByCategory function
+   *
+   * Ensures the function correctly fetches posts filtered by category,
+   * properly constructs the GraphQL query with the category parameter,
+   * and handles cases where no posts are found.
+   */
+  describe('getPostsByCategory', () => {
+    it('fetches posts by category', async () => {
+      const category = 'Blog';
+
+      // Mock successful response with filtered posts
+      const mockPostsResponse = {
+        data: {
+          postCollection: {
+            items: [mockPosts[0]] // Only post with 'Blog' category
+          }
+        }
+      };
+
+      (fetchGraphQL as any).mockResolvedValue(mockPostsResponse);
+
+      const result = await postAPI.getPostsByCategory(category);
+
+      // Verify the result
+      expect(result?.items).toHaveLength(1);
+      expect(result?.items?.[0]?.categories).toContain('Blog');
+
+      // Verify fetchGraphQL was called with correct query and variables
+      expect(fetchGraphQL).toHaveBeenCalledWith(
+        expect.stringContaining('GetPostsByCategory'),
+        { category, preview: false },
+        false
+      );
+
+      // Verify the query includes category filter
+      expect(fetchGraphQL).toHaveBeenCalledWith(
+        expect.stringContaining('categories_contains_some: [$category]'),
+        { category, preview: false },
+        false
+      );
+    });
+
+    it('returns empty array when no posts found for category', async () => {
+      // Mock response with no posts
+      const mockEmptyResponse = {
+        data: {
+          postCollection: {
+            items: []
+          }
+        }
+      };
+
+      (fetchGraphQL as any).mockResolvedValue(mockEmptyResponse);
+
+      const result = await postAPI.getPostsByCategory('NonExistentCategory');
+
+      expect(result?.items).toHaveLength(0);
+    });
+
+    it('uses preview token when preview is true', async () => {
+      const category = 'Blog';
+
+      // Mock successful response
+      const mockPostsResponse = {
+        data: {
+          postCollection: {
+            items: [mockPosts[0]]
+          }
+        }
+      };
+
+      (fetchGraphQL as any).mockResolvedValue(mockPostsResponse);
+
+      await postAPI.getPostsByCategory(category, true);
+
+      // Verify fetchGraphQL was called with preview parameter
+      expect(fetchGraphQL).toHaveBeenCalledWith(
+        expect.any(String),
+        { category, preview: true },
+        true
+      );
+    });
+
+    it('throws ContentfulError when response is invalid', async () => {
+      // Mock invalid response
+      (fetchGraphQL as any).mockResolvedValue({
+        data: null
+      });
+
+      await expect(postAPI.getPostsByCategory('Blog')).rejects.toThrow(ContentfulError);
+      await expect(postAPI.getPostsByCategory('Blog')).rejects.toThrow(
+        'Invalid response from Contentful'
+      );
+    });
+
+    it('passes through ContentfulError when thrown by fetchGraphQL', async () => {
+      // Mock ContentfulError from fetchGraphQL
+      const error = new ContentfulError('Test error from fetchGraphQL');
+      (fetchGraphQL as any).mockRejectedValue(error);
+
+      await expect(postAPI.getPostsByCategory('Blog')).rejects.toThrow(ContentfulError);
+      await expect(postAPI.getPostsByCategory('Blog')).rejects.toThrow('Test error from fetchGraphQL');
+    });
+
+    it('wraps Error in NetworkError when thrown by fetchGraphQL', async () => {
+      // Mock standard Error from fetchGraphQL
+      const error = new Error('Network failure');
+      (fetchGraphQL as any).mockRejectedValue(error);
+
+      await expect(postAPI.getPostsByCategory('Blog')).rejects.toThrow(NetworkError);
+      await expect(postAPI.getPostsByCategory('Blog')).rejects.toThrow(
+        'Error fetching Posts by category: Network failure'
+      );
+    });
+
+    it('handles unknown errors', async () => {
+      // Mock unknown error
+      (fetchGraphQL as any).mockRejectedValue('Unknown error');
+
+      await expect(postAPI.getPostsByCategory('Blog')).rejects.toThrow('Unknown error fetching Posts by category');
+    });
+  });
+});

--- a/src/app/[slug]/[pageSlug]/page.tsx
+++ b/src/app/[slug]/[pageSlug]/page.tsx
@@ -157,7 +157,7 @@ export default async function NestedPage({ params, searchParams }: NestedPagePro
           </nav>
         </div>
 
-        <h1 className="sr-only ">{page.name}</h1>
+        <h1 className="sr-only">{page.name}</h1>
 
         {/* Render the page content components */}
         {page.pageContentCollection?.items.map((component) => {

--- a/src/components/ContentGrid.tsx
+++ b/src/components/ContentGrid.tsx
@@ -76,9 +76,20 @@ export function ContentGrid(props: ContentGrid) {
 
             {/* items */}
             <Box cols={{ base: 1, lg: isFullWidthGrid ? 1 : 3 }} gap={12}>
-              {contentGrid.itemsCollection?.items?.map((item, index) => (
-                <ContentGridItem key={item.sys?.id || index} {...item} />
-              ))}
+              {contentGrid.itemsCollection?.items?.map((item, index) => {
+                // Skip empty/incomplete items
+                if (!item || (!item.title && !item.__typename)) {
+                  return null;
+                }
+                
+                // Handle Post items - render empty div for now
+                if (item.__typename === 'Post') {
+                  return <div key={item.sys?.id || index}>Post placeholder</div>;
+                }
+                
+                // Only render ContentGridItem for actual ContentGridItem types
+                return <ContentGridItem key={item.sys?.id || index} {...item} />;
+              })}
             </Box>
           </Box>
         </Container>

--- a/src/components/global/PostCard.tsx
+++ b/src/components/global/PostCard.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+import {
+  useContentfulLiveUpdates,
+  useContentfulInspectorMode
+} from '@contentful/live-preview/react';
+import { Box } from '@/components/global/matic-ds';
+import AirImage from '@/components/global/AirImage';
+import type { Post } from '@/types/contentful/Post';
+import Link from 'next/link';
+
+// Helper function to format date as "Month Day, Year"
+const formatDate = (dateString?: string): string => {
+  if (!dateString) return '';
+
+  const date = new Date(dateString);
+  return date.toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric'
+  });
+};
+
+export function PostCard(props: Post) {
+  const post = useContentfulLiveUpdates(props);
+  const inspectorProps = useContentfulInspectorMode({ entryId: post?.sys?.id });
+
+  console.log('post props', props);
+
+  return (
+    <Link href={`/`} {...inspectorProps({ fieldId: 'slug' })} className="flex h-full">
+      <Box direction="col" gap={0} className="">
+        <AirImage
+          link={post.mainImage?.link}
+          altText={post.mainImage?.altText}
+          className="min-h-[11.8rem] w-full object-cover"
+        />
+        <Box direction="col" gap={0} className="h-full justify-between bg-[#f6f6f6]">
+          <Box direction="col" gap={0} className="gap-[0.5rem] p-[1.5rem]">
+            <p className="text-body-xs uppercase" {...inspectorProps({ fieldId: 'categories' })}>
+              {' '}
+              {post.categories}
+            </p>
+            <h2
+              className="text-headline-xs leading-[120%]"
+              {...inspectorProps({ fieldId: 'title' })}
+            >
+              {' '}
+              {post.title}
+            </h2>
+          </Box>
+          <Box direction="row" gap={2} className="items-center justify-between pl-[1.5rem]">
+            <p
+              className="text-body-xs text-[#9A9A9A]"
+              {...inspectorProps({ fieldId: 'datePublished' })}
+            >
+              {formatDate(post.datePublished)}
+            </p>
+            <Box direction="col" gap={0} className="bg-white p-[1.25rem]">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="20"
+                height="20"
+                viewBox="0 0 20 20"
+                fill="none"
+              >
+                <g clipPath="url(#clip0_7391_79602)">
+                  <path
+                    d="M1 1H19M19 1V19M19 1L1 19"
+                    stroke="#5B5B5B"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                </g>
+                <defs>
+                  <clipPath id="clip0_7391_79602">
+                    <rect width="20" height="20" fill="white" />
+                  </clipPath>
+                </defs>
+              </svg>
+            </Box>
+          </Box>
+        </Box>
+      </Box>
+    </Link>
+  );
+}

--- a/src/components/global/modals/RequestAQuoteModal.tsx
+++ b/src/components/global/modals/RequestAQuoteModal.tsx
@@ -35,7 +35,7 @@ export function RequestAQuoteModal({
           portalId="12345678"
           formId="12345678-1234-1234-1234-123456789012"
           onSubmit={() => onOpenChange(false)}
-        /> */} 
+        /> */}
       </DialogContent>
     </Dialog>
   );

--- a/src/lib/contentful-api/content-grid.ts
+++ b/src/lib/contentful-api/content-grid.ts
@@ -3,6 +3,7 @@ import { fetchGraphQL } from '../api';
 import type { ContentGrid, ContentGridResponse } from '@/types/contentful';
 
 import { SECTIONHEADING_GRAPHQL_FIELDS } from './section-heading';
+import { POST_GRAPHQL_FIELDS_SIMPLE } from './post';
 
 import { ContentfulError, NetworkError } from '../errors';
 
@@ -62,6 +63,9 @@ export const CONTENTGRID_GRAPHQL_FIELDS = `
     items {
       ... on ContentGridItem {
         ${CONTENTGRIDITEM_GRAPHQL_FIELDS}
+      }
+      ... on Post {
+        ${POST_GRAPHQL_FIELDS_SIMPLE}
       }
     }
   }

--- a/src/lib/contentful-api/post.ts
+++ b/src/lib/contentful-api/post.ts
@@ -18,6 +18,26 @@ export const POST_GRAPHQL_FIELDS_SIMPLE = `
   slug
   excerpt
   datePublished
+  mainImage {
+    sys {
+      id
+    }
+    internalName
+    link
+    altText
+  }
+  content {
+    json
+  }
+  authorsCollection(limit: 2) {
+    items {
+      sys {
+        id
+      }
+      name
+      jobTitle
+    }
+  }
   categories
 `;
 

--- a/src/lib/contentful-api/post.ts
+++ b/src/lib/contentful-api/post.ts
@@ -1,0 +1,253 @@
+import { fetchGraphQL } from '../api';
+
+import type { Post, PostResponse } from '@/types/contentful/Post';
+
+import { ContentfulError, NetworkError } from '../errors';
+
+const SYS_FIELDS = `
+  sys {
+    id
+  }
+  __typename
+`;
+
+// Simplified Post fields for ContentGrid (to avoid complexity limits)
+export const POST_GRAPHQL_FIELDS_SIMPLE = `
+  ${SYS_FIELDS}
+  title
+  slug
+  excerpt
+  datePublished
+  categories
+`;
+
+// Full Post fields for individual Post queries
+export const POST_GRAPHQL_FIELDS = `
+  ${SYS_FIELDS}
+  title
+  slug
+  excerpt
+  datePublished
+  mainImage {
+    sys {
+      id
+    }
+    internalName
+    link
+    altText
+  }
+  content {
+    json
+  }
+  authorsCollection(limit: 5) {
+    items {
+      sys {
+        id
+      }
+      name
+      jobTitle
+      bio {
+        json
+      }
+    }
+  }
+  categories
+  tags
+  openGraphImage {
+    sys {
+      id
+    }
+    internalName
+    link
+    altText
+  }
+  seoTitle
+  seoDescription
+  seoFocusKeyword
+`;
+
+/**
+ * Fetches all Posts from Contentful
+ * @param preview - Whether to fetch draft content
+ * @returns Promise resolving to Posts response with pagination info
+ */
+export async function getAllPosts(preview = false): Promise<PostResponse> {
+  try {
+    const response = await fetchGraphQL<Post>(
+      `query GetAllPosts($preview: Boolean!) {
+        postCollection(preview: $preview, order: datePublished_DESC) {
+          items {
+            ${POST_GRAPHQL_FIELDS}
+          }
+        }
+      }`,
+      { preview },
+      preview
+    );
+
+    // Check for valid response
+    if (!response?.data) {
+      throw new ContentfulError('Invalid response from Contentful');
+    }
+
+    // Access data using type assertion to help TypeScript understand the structure
+    const data = response.data as unknown as { postCollection?: { items?: Post[] } };
+
+    // Validate the data structure
+    if (!data.postCollection?.items?.length) {
+      throw new ContentfulError('Failed to fetch Posts from Contentful');
+    }
+
+    return {
+      items: data.postCollection.items
+    };
+  } catch (error) {
+    if (error instanceof ContentfulError) {
+      throw error;
+    }
+    if (error instanceof Error) {
+      throw new NetworkError(`Error fetching Posts: ${error.message}`);
+    }
+    throw new Error('Unknown error fetching Posts');
+  }
+}
+
+/**
+ * Fetches a single Post by ID from Contentful
+ * @param id - The ID of the Post to fetch
+ * @param preview - Whether to fetch draft content
+ * @returns Promise resolving to Post or null if not found
+ */
+export async function getPostById(id: string, preview = false): Promise<Post | null> {
+  try {
+    const response = await fetchGraphQL<Post>(
+      `query GetPostById($id: String!, $preview: Boolean!) {
+        post(id: $id, preview: $preview) {
+          ${POST_GRAPHQL_FIELDS}
+        }
+      }`,
+      { id, preview },
+      preview
+    );
+
+    // Check for valid response
+    if (!response?.data) {
+      throw new ContentfulError('Invalid response from Contentful');
+    }
+
+    // Access data using type assertion to help TypeScript understand the structure
+    const data = response.data as unknown as { post?: Post };
+
+    // Return null if post not found
+    if (!data.post) {
+      return null;
+    }
+
+    return data.post;
+  } catch (error) {
+    if (error instanceof ContentfulError) {
+      throw error;
+    }
+    if (error instanceof Error) {
+      throw new NetworkError(`Error fetching Post: ${error.message}`);
+    }
+    throw new Error('Unknown error fetching Post');
+  }
+}
+
+/**
+ * Fetches a single Post by slug from Contentful
+ * @param slug - The slug of the Post to fetch
+ * @param preview - Whether to fetch draft content
+ * @returns Promise resolving to Post or null if not found
+ */
+export async function getPostBySlug(slug: string, preview = false): Promise<Post | null> {
+  try {
+    const response = await fetchGraphQL<Post>(
+      `query GetPostBySlug($slug: String!, $preview: Boolean!) {
+        postCollection(where: { slug: $slug }, limit: 1, preview: $preview) {
+          items {
+            ${POST_GRAPHQL_FIELDS}
+          }
+        }
+      }`,
+      { slug, preview },
+      preview
+    );
+
+    // Check for valid response
+    if (!response?.data) {
+      throw new ContentfulError('Invalid response from Contentful');
+    }
+
+    // Access data using type assertion to help TypeScript understand the structure
+    const data = response.data as unknown as { postCollection?: { items?: Post[] } };
+
+    // Return null if post not found
+    if (!data.postCollection?.items?.length) {
+      return null;
+    }
+
+    const post = data.postCollection.items[0];
+    if (!post) {
+      return null;
+    }
+
+    return post;
+  } catch (error) {
+    if (error instanceof ContentfulError) {
+      throw error;
+    }
+    if (error instanceof Error) {
+      throw new NetworkError(`Error fetching Post by slug: ${error.message}`);
+    }
+    throw new Error('Unknown error fetching Post by slug');
+  }
+}
+
+/**
+ * Fetches Posts by category from Contentful
+ * @param category - The category to filter by
+ * @param preview - Whether to fetch draft content
+ * @returns Promise resolving to Posts response with pagination info
+ */
+export async function getPostsByCategory(category: string, preview = false): Promise<PostResponse> {
+  try {
+    const response = await fetchGraphQL<Post>(
+      `query GetPostsByCategory($category: String!, $preview: Boolean!) {
+        postCollection(where: { categories_contains_some: [$category] }, preview: $preview, order: datePublished_DESC) {
+          items {
+            ${POST_GRAPHQL_FIELDS}
+          }
+        }
+      }`,
+      { category, preview },
+      preview
+    );
+
+    // Check for valid response
+    if (!response?.data) {
+      throw new ContentfulError('Invalid response from Contentful');
+    }
+
+    // Access data using type assertion to help TypeScript understand the structure
+    const data = response.data as unknown as { postCollection?: { items?: Post[] } };
+
+    // Return empty array if no posts found
+    if (!data.postCollection?.items) {
+      return { items: [] };
+    }
+
+    return {
+      items: data.postCollection.items
+    };
+  } catch (error) {
+    if (error instanceof ContentfulError) {
+      throw error;
+    }
+    if (error instanceof Error) {
+      throw new NetworkError(`Error fetching Posts by category: ${error.message}`);
+    }
+    throw new Error('Unknown error fetching Posts by category');
+  }
+}

--- a/src/types/contentful/ContentGrid.ts
+++ b/src/types/contentful/ContentGrid.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 import { AssetSchema } from './Asset';
 import { SectionHeadingSchema } from './SectionHeading';
 import { ImageSchema } from './Image';
+import { PostSchema } from './Post';
 
 // Define the ContentGridItem schema
 export const ContentGridItemSchema = z.object({
@@ -23,6 +24,10 @@ export const ContentGridItemSchema = z.object({
 
 export type ContentGridItem = z.infer<typeof ContentGridItemSchema>;
 
+// Union type for items that can be either ContentGridItem or Post
+const ContentGridItemUnion = z.union([ContentGridItemSchema, PostSchema]);
+export type ContentGridItemOrPost = z.infer<typeof ContentGridItemUnion>;
+
 export const ContentGridSchema = z.object({
   sys: z.object({
     id: z.string()
@@ -30,7 +35,7 @@ export const ContentGridSchema = z.object({
   title: z.string(),
   heading: SectionHeadingSchema,
   itemsCollection: z.object({
-    items: z.array(ContentGridItemSchema)
+    items: z.array(ContentGridItemUnion)
   }),
   __typename: z.string().optional()
 });

--- a/src/types/contentful/Post.ts
+++ b/src/types/contentful/Post.ts
@@ -1,0 +1,61 @@
+import { z } from 'zod';
+import { ImageSchema } from './Image';
+
+// Post category options as defined in the content model
+const PostCategorySchema = z.enum([
+  'Blog',
+  'Case Study',
+  'Data Sheet',
+  'Featured',
+  'In The News',
+  'Press Release',
+  'Resources',
+  'Shug Speaks',
+  'Video'
+]);
+
+// Team member schema (referenced by authors)
+const TeamMemberSchema = z.object({
+  sys: z.object({
+    id: z.string()
+  }),
+  name: z.string().optional(),
+  title: z.string().optional(),
+  bio: z.string().optional(),
+  __typename: z.string().optional()
+});
+
+// Rich text content schema (simplified for the content field)
+const RichTextSchema = z.object({
+  nodeType: z.string(),
+  data: z.record(z.any()).optional(),
+  content: z.array(z.any()).optional()
+});
+
+export const PostSchema = z.object({
+  sys: z.object({
+    id: z.string()
+  }),
+  title: z.string(),
+  slug: z.string(),
+  excerpt: z.string().optional(),
+  datePublished: z.string().optional(),
+  mainImage: ImageSchema.optional(),
+  content: RichTextSchema,
+  authors: z.array(TeamMemberSchema),
+  categories: z.array(PostCategorySchema),
+  tags: z.array(z.string()).optional(),
+  openGraphImage: ImageSchema.optional(),
+  seoTitle: z.string().optional(),
+  seoDescription: z.string().optional(),
+  seoFocusKeyword: z.string().optional(),
+  __typename: z.string().optional()
+});
+
+export type Post = z.infer<typeof PostSchema>;
+export type PostCategory = z.infer<typeof PostCategorySchema>;
+export type TeamMember = z.infer<typeof TeamMemberSchema>;
+
+export interface PostResponse {
+  items: Post[];
+}

--- a/src/types/contentful/index.ts
+++ b/src/types/contentful/index.ts
@@ -8,5 +8,6 @@ export * from './Hero';
 export * from './Image';
 export * from './Page';
 export * from './PageList';
+export * from './Post';
 export * from './SectionHeading';
 export * from './GraphQLResponse';


### PR DESCRIPTION

## Summary
Posts can now be rendered alongside other content types within ContentGrid collections.

## Files Added/Modified

### Core Post Implementation
- `src/types/contentful/Post.ts` - Post type definitions using Zod schema validation
- [src/lib/contentful-api/post.ts] - Post API functions with GraphQL queries and error handling
- [src/__tests__/lib/contentful-api/post.test.ts] - Comprehensive test suite covering all Post API functions

### ContentGrid Union Type Support
- [src/types/contentful/ContentGrid.ts] - Updated schema to accept both Post and ContentGridItem types
- [src/components/ContentGrid.tsx] - Enhanced with runtime type guards and dynamic layout logic
- [src/lib/contentful-api/content-grid.ts] - Updated GraphQL queries to fetch union types

### PostCard Component
- [src/components/global/PostCard.tsx] - New component for rendering Posts with formatted dates, images, categories, and navigation

### Smart Type Detection
The ContentGrid component now uses runtime type guards to safely distinguish between Posts and ContentGridItems, ensuring the correct component is rendered for each content type.

### Dynamic Layouts
The grid automatically adjusts its layout based on content:
- Four-column layout for Post-only collections
- Three-column layout for mixed content types
- Responsive design that works across all screen sizes