### PR TITLE
Refactor/Product Cards as Feature Items

### DIFF
--- a/src/components/ContentGrid.tsx
+++ b/src/components/ContentGrid.tsx
@@ -9,6 +9,7 @@ import { PostCard } from '@/components/global/PostCard';
 import { Slider } from '@/components/Slider';
 import { SolutionCard } from '@/components/SolutionCard';
 import { ServiceCard } from '@/components/global/ServiceCard';
+import { ProductCard } from '@/components/global/ProductCard';
 import { MuxVideo } from '@/components/media/MuxVideo';
 import { SectionHeading } from '@/components/SectionHeading';
 import AirImage from '@/components/media/AirImage';
@@ -18,6 +19,7 @@ import type {
   ContentGridItem as ContentGridItemType,
   VideoSys as VideoType,
   Post as PostType,
+  ProductSys as ProductType,
   Service as ServiceType,
   SliderSys as SliderType,
   SolutionSys as SolutionType
@@ -131,6 +133,17 @@ export function ContentGrid(props: ContentGrid) {
                       if (isVideo) {
                         // Type assertion since we've verified it's a proper Video
                         return <MuxVideo key={item.sys?.id || index} {...(item as VideoType)} />;
+                      }
+
+                      // Type guard: Check if item is a Product with essential Product structure
+                      const isProduct = item.__typename === 'Product';
+
+                      if (isProduct) {
+                        const product = item as ProductType;
+                        // Transform Product to ContentGridItem format, mapping slug to link and icon to image
+                        return (
+                          <ProductCard key={item.sys?.id || index} {...(item as ProductType)} />
+                        );
                       }
 
                       // Type guard: Check if item is a Solution with essential Solution structure

--- a/src/components/ContentGridItem.tsx
+++ b/src/components/ContentGridItem.tsx
@@ -16,14 +16,24 @@ export function ContentGridItem(props: ContentGridItemType) {
 
   // Render the appropriate icon based on the icon name
   const renderIcon = () => {
+    // Only render icon if it exists and has a valid URL
+    if (!icon?.url) {
+      return (
+        <div className="group-hover:bg-primary mb-4 inline-flex h-16 w-16 items-center justify-center bg-black p-2">
+          {/* Placeholder for when no icon is available */}
+          <div className="h-8 w-8 rounded bg-white/20" />
+        </div>
+      );
+    }
+
     return (
       <div className="group-hover:bg-primary mb-4 inline-flex h-16 w-16 items-center justify-center bg-black p-2">
         <Image
-          src={icon?.url ?? ''}
-          alt={`${icon?.title} icon`}
+          src={icon.url}
+          alt={`${icon.title ?? 'Icon'}`}
           className="h-full w-full"
-          width={icon?.width}
-          height={icon?.height}
+          width={icon.width}
+          height={icon.height}
           {...inspectorProps({ fieldId: 'icon' })}
         />
       </div>

--- a/src/components/global/ProductCard.tsx
+++ b/src/components/global/ProductCard.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+import {
+  useContentfulLiveUpdates,
+  useContentfulInspectorMode
+} from '@contentful/live-preview/react';
+import { Box } from '@/components/global/matic-ds';
+import Image from 'next/image';
+import type { Product, ProductSys } from '@/types/contentful/Product';
+import Link from 'next/link';
+import { getProductsByIds } from '@/lib/contentful-api/product';
+import { useEffect, useState } from 'react';
+
+export const ProductCard = (props: ProductSys) => {
+  const inspectorProps = useContentfulInspectorMode({ entryId: props.sys?.id });
+  const [productData, setProductData] = useState<Product | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchProductData = async () => {
+      try {
+        const products = await getProductsByIds([props.sys.id]);
+        if (products.length > 0 && products[0]) {
+          setProductData(products[0]);
+        }
+      } catch (error) {
+        console.error('Error fetching product data:', error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    void fetchProductData();
+  }, [props.sys.id]);
+
+  if (loading) {
+    return <div>Loading...</div>;
+  }
+
+  if (!productData) {
+    return <div>Product not found</div>;
+  }
+  return (
+    <Link
+      href={`/${productData.slug}`}
+      {...inspectorProps({ fieldId: 'slug' })}
+      className="group flex flex-col"
+    >
+      <Box direction="col" gap={4}>
+        <Box className="group-hover:bg-primary w-fit bg-black p-[0.38rem]">
+          <Image
+            src={productData.icon?.url ?? ''}
+            alt={productData.title}
+            className=""
+            width={60}
+            height={60}
+          />
+        </Box>
+        <Box direction="col" gap={2}>
+          <Box direction="row" gap={2} className="items-center">
+            <h3 className="text-headline-sm group-hover:text-primary">{productData.title}</h3>
+            <div className="opacity-0 group-hover:opacity-100">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="30"
+                height="29"
+                viewBox="0 0 30 29"
+                fill="none"
+              >
+                <path
+                  d="M5.99963 6H23.9996M23.9996 6V23M23.9996 6L5.99963 23"
+                  stroke="#FE5000"
+                  strokeWidth="1.5"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </div>
+          </Box>
+          <p className="text-body-sm group-hover:text-primary">{productData.description}</p>
+        </Box>
+      </Box>
+    </Link>
+  );
+};

--- a/src/components/ui/carousel.tsx
+++ b/src/components/ui/carousel.tsx
@@ -1,108 +1,106 @@
-"use client"
+'use client';
 
-import * as React from "react"
-import useEmblaCarousel, {
-  type UseEmblaCarouselType,
-} from "embla-carousel-react"
-import { ArrowLeft, ArrowRight } from "lucide-react"
+import * as React from 'react';
+import useEmblaCarousel, { type UseEmblaCarouselType } from 'embla-carousel-react';
+import { ArrowLeft, ArrowRight } from 'lucide-react';
 
-import { cn } from "@/lib/utils"
-import { Button } from "@/components/ui/button"
+import { cn } from '@/lib/utils';
+import { Button } from '@/components/ui/button';
 
-type CarouselApi = UseEmblaCarouselType[1]
-type UseCarouselParameters = Parameters<typeof useEmblaCarousel>
-type CarouselOptions = UseCarouselParameters[0]
-type CarouselPlugin = UseCarouselParameters[1]
+type CarouselApi = UseEmblaCarouselType[1];
+type UseCarouselParameters = Parameters<typeof useEmblaCarousel>;
+type CarouselOptions = UseCarouselParameters[0];
+type CarouselPlugin = UseCarouselParameters[1];
 
 type CarouselProps = {
-  opts?: CarouselOptions
-  plugins?: CarouselPlugin
-  orientation?: "horizontal" | "vertical"
-  setApi?: (api: CarouselApi) => void
-}
+  opts?: CarouselOptions;
+  plugins?: CarouselPlugin;
+  orientation?: 'horizontal' | 'vertical';
+  setApi?: (api: CarouselApi) => void;
+};
 
 type CarouselContextProps = {
-  carouselRef: ReturnType<typeof useEmblaCarousel>[0]
-  api: ReturnType<typeof useEmblaCarousel>[1]
-  scrollPrev: () => void
-  scrollNext: () => void
-  canScrollPrev: boolean
-  canScrollNext: boolean
-} & CarouselProps
+  carouselRef: ReturnType<typeof useEmblaCarousel>[0];
+  api: ReturnType<typeof useEmblaCarousel>[1];
+  scrollPrev: () => void;
+  scrollNext: () => void;
+  canScrollPrev: boolean;
+  canScrollNext: boolean;
+} & CarouselProps;
 
-const CarouselContext = React.createContext<CarouselContextProps | null>(null)
+const CarouselContext = React.createContext<CarouselContextProps | null>(null);
 
 function useCarousel() {
-  const context = React.useContext(CarouselContext)
+  const context = React.useContext(CarouselContext);
 
   if (!context) {
-    throw new Error("useCarousel must be used within a <Carousel />")
+    throw new Error('useCarousel must be used within a <Carousel />');
   }
 
-  return context
+  return context;
 }
 
 function Carousel({
-  orientation = "horizontal",
+  orientation = 'horizontal',
   opts,
   setApi,
   plugins,
   className,
   children,
   ...props
-}: React.ComponentProps<"div"> & CarouselProps) {
+}: React.ComponentProps<'div'> & CarouselProps) {
   const [carouselRef, api] = useEmblaCarousel(
     {
       ...opts,
-      axis: orientation === "horizontal" ? "x" : "y",
+      axis: orientation === 'horizontal' ? 'x' : 'y'
     },
     plugins
-  )
-  const [canScrollPrev, setCanScrollPrev] = React.useState(false)
-  const [canScrollNext, setCanScrollNext] = React.useState(false)
+  );
+  const [canScrollPrev, setCanScrollPrev] = React.useState(false);
+  const [canScrollNext, setCanScrollNext] = React.useState(false);
 
   const onSelect = React.useCallback((api: CarouselApi) => {
-    if (!api) return
-    setCanScrollPrev(api.canScrollPrev())
-    setCanScrollNext(api.canScrollNext())
-  }, [])
+    if (!api) return;
+    setCanScrollPrev(api.canScrollPrev());
+    setCanScrollNext(api.canScrollNext());
+  }, []);
 
   const scrollPrev = React.useCallback(() => {
-    api?.scrollPrev()
-  }, [api])
+    api?.scrollPrev();
+  }, [api]);
 
   const scrollNext = React.useCallback(() => {
-    api?.scrollNext()
-  }, [api])
+    api?.scrollNext();
+  }, [api]);
 
   const handleKeyDown = React.useCallback(
     (event: React.KeyboardEvent<HTMLDivElement>) => {
-      if (event.key === "ArrowLeft") {
-        event.preventDefault()
-        scrollPrev()
-      } else if (event.key === "ArrowRight") {
-        event.preventDefault()
-        scrollNext()
+      if (event.key === 'ArrowLeft') {
+        event.preventDefault();
+        scrollPrev();
+      } else if (event.key === 'ArrowRight') {
+        event.preventDefault();
+        scrollNext();
       }
     },
     [scrollPrev, scrollNext]
-  )
+  );
 
   React.useEffect(() => {
-    if (!api || !setApi) return
-    setApi(api)
-  }, [api, setApi])
+    if (!api || !setApi) return;
+    setApi(api);
+  }, [api, setApi]);
 
   React.useEffect(() => {
-    if (!api) return
-    onSelect(api)
-    api.on("reInit", onSelect)
-    api.on("select", onSelect)
+    if (!api) return;
+    onSelect(api);
+    api.on('reInit', onSelect);
+    api.on('select', onSelect);
 
     return () => {
-      api?.off("select", onSelect)
-    }
-  }, [api, onSelect])
+      api?.off('select', onSelect);
+    };
+  }, [api, onSelect]);
 
   return (
     <CarouselContext.Provider
@@ -110,17 +108,16 @@ function Carousel({
         carouselRef,
         api: api,
         opts,
-        orientation:
-          orientation || (opts?.axis === "y" ? "vertical" : "horizontal"),
+        orientation: orientation || (opts?.axis === 'y' ? 'vertical' : 'horizontal'),
         scrollPrev,
         scrollNext,
         canScrollPrev,
-        canScrollNext,
+        canScrollNext
       }}
     >
       <div
         onKeyDownCapture={handleKeyDown}
-        className={cn("relative", className)}
+        className={cn('relative', className)}
         role="region"
         aria-roledescription="carousel"
         data-slot="carousel"
@@ -129,32 +126,24 @@ function Carousel({
         {children}
       </div>
     </CarouselContext.Provider>
-  )
+  );
 }
 
-function CarouselContent({ className, ...props }: React.ComponentProps<"div">) {
-  const { carouselRef, orientation } = useCarousel()
+function CarouselContent({ className, ...props }: React.ComponentProps<'div'>) {
+  const { carouselRef, orientation } = useCarousel();
 
   return (
-    <div
-      ref={carouselRef}
-      className="overflow-hidden"
-      data-slot="carousel-content"
-    >
+    <div ref={carouselRef} className="overflow-hidden" data-slot="carousel-content">
       <div
-        className={cn(
-          "flex",
-          orientation === "horizontal" ? "-ml-4" : "-mt-4 flex-col",
-          className
-        )}
+        className={cn('flex', orientation === 'horizontal' ? '-ml-4' : '-mt-4 flex-col', className)}
         {...props}
       />
     </div>
-  )
+  );
 }
 
-function CarouselItem({ className, ...props }: React.ComponentProps<"div">) {
-  const { orientation } = useCarousel()
+function CarouselItem({ className, ...props }: React.ComponentProps<'div'>) {
+  const { orientation } = useCarousel();
 
   return (
     <div
@@ -162,22 +151,22 @@ function CarouselItem({ className, ...props }: React.ComponentProps<"div">) {
       aria-roledescription="slide"
       data-slot="carousel-item"
       className={cn(
-        "min-w-0 shrink-0 grow-0 basis-full",
-        orientation === "horizontal" ? "pl-4" : "pt-4",
+        'min-w-0 shrink-0 grow-0 basis-full',
+        orientation === 'horizontal' ? 'pl-4' : 'pt-4',
         className
       )}
       {...props}
     />
-  )
+  );
 }
 
 function CarouselPrevious({
   className,
-  variant = "outline",
-  size = "icon",
+  variant = 'outline',
+  size = 'icon',
   ...props
 }: React.ComponentProps<typeof Button>) {
-  const { orientation, scrollPrev, canScrollPrev } = useCarousel()
+  const { orientation, scrollPrev, canScrollPrev } = useCarousel();
 
   return (
     <Button
@@ -185,10 +174,10 @@ function CarouselPrevious({
       variant={variant}
       size={size}
       className={cn(
-        "absolute size-8 rounded-full",
-        orientation === "horizontal"
-          ? "top-1/2 -left-12 -translate-y-1/2"
-          : "-top-12 left-1/2 -translate-x-1/2 rotate-90",
+        'absolute size-8 rounded-full',
+        orientation === 'horizontal'
+          ? 'top-1/2 -left-12 -translate-y-1/2'
+          : '-top-12 left-1/2 -translate-x-1/2 rotate-90',
         className
       )}
       disabled={!canScrollPrev}
@@ -198,16 +187,16 @@ function CarouselPrevious({
       <ArrowLeft />
       <span className="sr-only">Previous slide</span>
     </Button>
-  )
+  );
 }
 
 function CarouselNext({
   className,
-  variant = "outline",
-  size = "icon",
+  variant = 'outline',
+  size = 'icon',
   ...props
 }: React.ComponentProps<typeof Button>) {
-  const { orientation, scrollNext, canScrollNext } = useCarousel()
+  const { orientation, scrollNext, canScrollNext } = useCarousel();
 
   return (
     <Button
@@ -215,10 +204,10 @@ function CarouselNext({
       variant={variant}
       size={size}
       className={cn(
-        "absolute size-8 rounded-full",
-        orientation === "horizontal"
-          ? "top-1/2 -right-12 -translate-y-1/2"
-          : "-bottom-12 left-1/2 -translate-x-1/2 rotate-90",
+        'absolute size-8 rounded-full',
+        orientation === 'horizontal'
+          ? 'top-1/2 -right-12 -translate-y-1/2'
+          : '-bottom-12 left-1/2 -translate-x-1/2 rotate-90',
         className
       )}
       disabled={!canScrollNext}
@@ -228,7 +217,7 @@ function CarouselNext({
       <ArrowRight />
       <span className="sr-only">Next slide</span>
     </Button>
-  )
+  );
 }
 
 export {
@@ -237,5 +226,5 @@ export {
   CarouselContent,
   CarouselItem,
   CarouselPrevious,
-  CarouselNext,
-}
+  CarouselNext
+};

--- a/src/lib/contentful-api/content-grid.ts
+++ b/src/lib/contentful-api/content-grid.ts
@@ -63,6 +63,9 @@ export const CONTENTGRID_GRAPHQL_FIELDS = `
       ... on Post {
         ${POST_GRAPHQL_FIELDS_SIMPLE}
       }
+      ... on Product {
+        ${SYS_FIELDS}
+      }
       ... on Service {
         ${SERVICE_GRAPHQL_FIELDS}
       }

--- a/src/lib/contentful-api/index.ts
+++ b/src/lib/contentful-api/index.ts
@@ -4,6 +4,7 @@ export * from './cta-banner';
 export * from './image-between';
 export * from './image';
 export * from './post';
+export * from './product';
 export * from './section-heading';
 export * from './service';
 export * from './slider';

--- a/src/lib/contentful-api/product.ts
+++ b/src/lib/contentful-api/product.ts
@@ -1,0 +1,80 @@
+import { fetchGraphQL } from '../api';
+import type { Product, ProductResponse } from '@/types/contentful/Product';
+import { ContentfulError, NetworkError } from '../errors';
+
+const SYS_FIELDS = `
+  sys {
+    id
+  }
+  __typename
+`;
+
+// Asset fields for icon
+const ASSET_FIELDS = `
+  sys {
+    id
+  }
+  title
+  description
+  url
+  width
+  height
+`;
+
+// Product fields
+export const PRODUCT_GRAPHQL_FIELDS = `
+  ${SYS_FIELDS}
+  title
+  slug
+  icon {
+    ${ASSET_FIELDS}
+  }
+  description
+`;
+
+export async function getProductsByIds(productsIds: string[], preview = false): Promise<Product[]> {
+  if (productsIds.length === 0) {
+    return [];
+  }
+
+  const query = `
+    query GetProductsByIds($ids: [String!]!, $preview: Boolean!) {
+      productCollection(where: { sys: { id_in: $ids } }, preview: $preview) {
+        items {
+          ${PRODUCT_GRAPHQL_FIELDS}
+        }
+      }
+    }
+  `;
+
+  try {
+    const response = await fetchGraphQL(query, {
+      ids: productsIds,
+      preview
+    });
+
+    if (!response?.data) {
+      throw new ContentfulError('Invalid response from Contentful');
+    }
+
+    // Access data using type assertion to help TypeScript understand the structure
+    const data = response.data as unknown as {
+      productCollection?: { items?: Product[] };
+    };
+
+    // Validate the data structure
+    if (!data.productCollection?.items?.length) {
+      throw new ContentfulError('Failed to fetch Products from Contentful');
+    }
+
+    return data.productCollection.items;
+  } catch (error) {
+    if (error instanceof ContentfulError) {
+      throw error;
+    }
+    if (error instanceof Error) {
+      throw new NetworkError(`Error fetching Products: ${error.message}`);
+    }
+    throw new Error('Unknown error fetching Products');
+  }
+}

--- a/src/types/contentful/Product.ts
+++ b/src/types/contentful/Product.ts
@@ -1,0 +1,28 @@
+import { z } from 'zod';
+import { AssetSchema } from './Asset';
+
+export const ProductSysSchema = z.object({
+  sys: z.object({
+    id: z.string()
+  }),
+  title: z.string(),
+  __typename: z.string().optional()
+});
+
+export const ProductSchema = z.object({
+  sys: z.object({
+    id: z.string()
+  }),
+  title: z.string(),
+  slug: z.string(),
+  icon: AssetSchema.optional(),
+  description: z.string().optional(),
+  __typename: z.string().optional()
+});
+
+export type Product = z.infer<typeof ProductSchema>;
+export type ProductSys = z.infer<typeof ProductSysSchema>;
+
+export interface ProductResponse {
+  items: Product[];
+}

--- a/src/types/contentful/index.ts
+++ b/src/types/contentful/index.ts
@@ -11,6 +11,7 @@ export * from './ImageBetween';
 export * from './Page';
 export * from './PageList';
 export * from './Post';
+export * from './Product';
 export * from './SectionHeading';
 export * from './Slider';
 export * from './Solution';


### PR DESCRIPTION
# Refactor: Product Cards as Feature Items

This pull request introduces the ability to display products as feature items within the content grid. It enhances the component and data structure to support product cards, allowing for a more versatile and commerce-focused content presentation.

## Changes

- **Introduced ProductCard Component**: A new component `src/components/global/ProductCard.tsx` has been created to display product information in a card format.
- **Updated Content Grid**: The `ContentGrid` and `ContentGridItem` components have been modified to support the new `ProductCard` component, enabling products to be seamlessly integrated into the existing grid layout.
- **Extended Contentful API**: The Contentful API has been updated to fetch product data. This includes a new `product.ts` API utility and updated interfaces in `src/types/contentful/Product.ts`.
- **Modified Carousel Component**: The `carousel.tsx` component was updated to accommodate the new product card functionality.

## Files Changed

- `src/components/ContentGrid.tsx`
- `src/components/ContentGridItem.tsx`
- `src/components/global/ProductCard.tsx`
- `src/components/ui/carousel.tsx`
- `src/lib/contentful-api/content-grid.ts`
- `src/lib/contentful-api/index.ts`
- `src/lib/contentful-api/product.ts`
- `src/types/contentful/Product.ts`
- `src/types/contentful/index.ts`