### PR TITLE
feat: add hover state to PostCard

### DIFF
--- a/src/components/global/PostCard.tsx
+++ b/src/components/global/PostCard.tsx
@@ -56,7 +56,7 @@ export function PostCard(props: Post) {
     <Link
       href={`/resources/${post.slug}`}
       {...inspectorProps({ fieldId: 'slug' })}
-      className="flex h-full"
+      className="flex h-full group"
     >
       <Box direction="col" gap={0} className="">
         <AirImage
@@ -69,13 +69,13 @@ export function PostCard(props: Post) {
             <p className="text-body-xs uppercase" {...inspectorProps({ fieldId: 'categories' })}>
               {post.categories.map((category, index) => (
                 <span key={index}>
-                  <span className={categoryColorMap(category)}>{category}</span>
+                  <span className={categoryColorMap(category) + ' group-hover:text-primary'}>{category}</span>
                   {index < post.categories.length - 1 ? ', ' : ''}
                 </span>
               ))}
             </p>
             <h2
-              className="text-headline-xs leading-[120%]"
+              className="text-headline-xs group-hover:text-primary leading-[120%]"
               {...inspectorProps({ fieldId: 'title' })}
             >
               {' '}
@@ -96,11 +96,11 @@ export function PostCard(props: Post) {
                 height="20"
                 viewBox="0 0 20 20"
                 fill="none"
+                className="stroke-[#5B5B5B] group-hover:stroke-primary"
               >
                 <g clipPath="url(#clip0_7391_79602)">
                   <path
                     d="M1 1H19M19 1V19M19 1L1 19"
-                    stroke="#5B5B5B"
                     strokeWidth="2"
                     strokeLinecap="round"
                     strokeLinejoin="round"


### PR DESCRIPTION
#Add Hover State to Post Card
Overview
This PR adds a hover state to the category, icon, and title in the PostCard component.

##Changes Made
Added group-hover:stroke-primary class to the SVG element
Moved the hardcoded stroke color from the path to the SVG's className
Ensured the hover state matches the existing design system's primary color

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211003155940053