### PR TITLE
ID-554 feat: adding SEO fields to reflect in frontend

### DIFF
--- a/src/app/[slug]/page.tsx
+++ b/src/app/[slug]/page.tsx
@@ -19,6 +19,7 @@
  */
 
 import { notFound } from 'next/navigation';
+import type { Metadata } from 'next';
 import { getPageBySlug, getPageListBySlug } from '@/lib/contentful-api';
 import { BannerHero } from '@/components/BannerHero';
 import { CtaBanner } from '@/components/CtaBanner';
@@ -33,6 +34,7 @@ import type { Footer as FooterType } from '@/types/contentful/Footer';
 import type { Page } from '@/types/contentful/Page';
 import type { PageList as PageListType } from '@/types/contentful/PageList';
 import type { CtaBanner as CtaBannerType } from '@/types/contentful/CtaBanner';
+import { extractOpenGraphImage, extractSEOTitle, extractSEODescription } from '@/lib/metadata-utils';
 
 // Define the component mapping for pageContent items
 const componentMap = {
@@ -54,6 +56,107 @@ export async function generateStaticParams() {
   // This would typically fetch all pages and page lists to pre-render
   // For now, we'll return an empty array as we're focusing on dynamic rendering
   return [];
+}
+
+// Generate metadata for SEO using Page component data
+export async function generateMetadata({ params }: ContentPageProps): Promise<Metadata> {
+  const resolvedParams = await params;
+  const slug = resolvedParams?.slug;
+  
+  if (!slug) {
+    return {
+      title: 'Page Not Found',
+      description: 'The requested page could not be found.'
+    };
+  }
+
+  // Construct the base URL for absolute image URLs
+  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://nextracker.com';
+  
+  try {
+    // Try to fetch as a Page first
+    const page = await getPageBySlug(slug, false);
+    
+    if (page) {
+      // Extract SEO data from Page component using utility functions
+      const title = extractSEOTitle(page, 'Nextracker');
+      const description = extractSEODescription(page, 'Nextracker Website');
+      
+      // Handle OG image from Page component
+      const openGraphImage = extractOpenGraphImage(page, baseUrl, title);
+      
+      const ogImages = openGraphImage ? [{
+        url: openGraphImage.url,
+        width: openGraphImage.width,
+        height: openGraphImage.height,
+        alt: openGraphImage.title ?? title
+      }] : [];
+
+      return {
+        title,
+        description,
+        openGraph: {
+          title,
+          description,
+          images: ogImages,
+          siteName: 'Nextracker',
+          type: 'website',
+          url: `${baseUrl}/${slug}`
+        },
+        twitter: {
+          card: 'summary_large_image',
+          title,
+          description,
+          images: openGraphImage ? [openGraphImage.url] : []
+        },
+        alternates: {
+          canonical: `${baseUrl}/${slug}`
+        }
+      };
+    }
+
+    // Try to fetch as a PageList
+    const pageList = await getPageListBySlug(slug, false);
+    
+    if (pageList) {
+      // Extract SEO data from PageList component (PageList doesn't have SEO fields, so use basic fields)
+      const title = pageList.title ?? 'Nextracker';
+      const description = 'Nextracker Website';
+      
+      return {
+        title,
+        description,
+        openGraph: {
+          title,
+          description,
+          siteName: 'Nextracker',
+          type: 'website',
+          url: `${baseUrl}/${slug}`
+        },
+        twitter: {
+          card: 'summary_large_image',
+          title,
+          description
+        },
+        alternates: {
+          canonical: `${baseUrl}/${slug}`
+        }
+      };
+    }
+
+    // If neither found, return 404 metadata
+    return {
+      title: 'Page Not Found',
+      description: 'The requested page could not be found.'
+    };
+    
+  } catch (error) {
+    console.error(`Error generating metadata for slug: ${slug}`, error);
+    return {
+      title: 'Error',
+      description: 'An error occurred while loading this page.'
+    };
+  }
 }
 
 // The dynamic content component that handles both Page and PageList

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -29,7 +29,16 @@ const inter = Inter({
 export const metadata: Metadata = {
   title: 'Nextracker',
   description: 'Modern content management and digital experiences',
-  icons: [{ rel: 'icon', url: '/favicon.ico' }]
+  icons: [{ rel: 'icon', url: '/favicon.ico' }],
+  viewport: 'width=device-width, initial-scale=1',
+  robots: 'index, follow',
+  openGraph: {
+    siteName: 'Nextracker',
+    type: 'website'
+  },
+  twitter: {
+    card: 'summary_large_image'
+  }
 };
 
 /**

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -39,43 +39,11 @@ export async function generateMetadata(): Promise<Metadata> {
   // Construct the base URL for absolute image URLs
   const baseUrl = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://nextracker.com';
 
-  // Type for the Open Graph image
-  type OpenGraphImage = {
-    url: string;
-    width?: number;
-    height?: number;
-    title?: string;
-  };
+  // Import utility functions for safe metadata extraction
+  const { extractOpenGraphImage, extractSEOTitle, extractSEODescription } = await import('@/lib/metadata-utils');
 
   // Safely extract the openGraphImage with proper typing
-  const openGraphImage: OpenGraphImage | undefined = (() => {
-    const img = homePage.openGraphImage as OpenGraphImage;
-    if (!img) return undefined;
-
-    const result: OpenGraphImage = { url: '' };
-
-    // Safely set URL with proper type checking
-    if (img && 'url' in img && typeof img.url === 'string') {
-      result.url = img.url;
-    }
-
-    // Safely set width with proper type checking
-    if (img && 'width' in img && typeof img.width === 'number') {
-      result.width = img.width;
-    }
-
-    // Safely set height with proper type checking
-    if (img && 'height' in img && typeof img.height === 'number') {
-      result.height = img.height;
-    }
-
-    // Safely set title with proper type checking
-    if (img && 'title' in img && typeof img.title === 'string') {
-      result.title = img.title;
-    }
-
-    return result.url ? result : undefined;
-  })();
+  const openGraphImage = extractOpenGraphImage(homePage, baseUrl, homePage?.title ?? 'Nextracker');
 
   // Safely extract image URL
   const getImageUrl = (url: string): string => {
@@ -98,9 +66,8 @@ export async function generateMetadata(): Promise<Metadata> {
     : [];
 
   // Build the metadata object with Open Graph tags
-  const title = homePage.seoTitle ?? homePage.title ?? defaultMetadata.title;
-  const description =
-    homePage.seoDescription ?? homePage.description ?? defaultMetadata.description;
+  const title = extractSEOTitle(homePage, defaultMetadata.title);
+  const description = extractSEODescription(homePage, defaultMetadata.description);
 
   return {
     title,

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -77,7 +77,8 @@ export async function generateMetadata(): Promise<Metadata> {
       description,
       images: ogImages,
       siteName: 'Nextracker',
-      type: 'website'
+      type: 'website',
+      url: baseUrl
     },
     twitter: {
       card: 'summary_large_image',

--- a/src/components/global/Page.tsx
+++ b/src/components/global/Page.tsx
@@ -28,6 +28,7 @@ import { Header } from './Header';
 import { Footer } from './Footer';
 import type { Header as HeaderType } from '@/types/contentful/Header';
 import type { Footer as FooterType } from '@/types/contentful/Footer';
+import type { Image as ImageType } from '@/types/contentful/Image';
 
 interface PageProps {
   sys: {
@@ -49,6 +50,9 @@ interface PageProps {
     }>;
   };
   __typename?: string; // Add typename for GraphQL identification
+  openGraphImage?: ImageType;
+  seoTitle?: string;
+  seoDescription?: string;
   // Add optional parentPageList prop to indicate if this page belongs to a PageList
   parentPageList?: {
     slug?: string;
@@ -181,7 +185,6 @@ export function Page(props: PageProps) {
           </div>
         )}
       </div>
-
       {/* Render the page-specific footer if available */}
       {page.footer && (
         <div

--- a/src/lib/contentful-api/page.ts
+++ b/src/lib/contentful-api/page.ts
@@ -9,12 +9,18 @@ import { IMAGEBETWEEN_GRAPHQL_FIELDS } from './image-between';
 
 import { getHeaderById } from './header';
 import { getFooterById } from './footer';
+import { IMAGE_GRAPHQL_FIELDS } from './image';
 
 export const PAGE_BASIC_FIELDS = `
   ${SYS_FIELDS}
   title
   slug
   description
+  openGraphImage {
+    ${IMAGE_GRAPHQL_FIELDS}
+  }
+  seoTitle
+  seoDescription
 `;
 
 // Page fields with header/footer references only (no full data)

--- a/src/lib/metadata-utils.ts
+++ b/src/lib/metadata-utils.ts
@@ -1,0 +1,140 @@
+/**
+ * Utility functions for safe metadata extraction from Contentful data
+ * These functions provide type-safe access to SEO fields while avoiding TypeScript/ESLint errors
+ */
+
+// Type definitions for metadata extraction
+export interface ContentfulImage {
+  link?: string;
+  title?: string;
+  altText?: string;
+}
+
+export interface ContentfulPageSEO {
+  title?: string;
+  seoTitle?: string;
+  seoDescription?: string;
+  description?: string;
+  openGraphImage?: ContentfulImage;
+}
+
+export interface OpenGraphImageResult {
+  url: string;
+  width: number;
+  height: number;
+  title?: string;
+}
+
+/**
+ * Type guard to check if an object has the expected Contentful image structure
+ */
+function isContentfulImage(obj: unknown): obj is ContentfulImage {
+  return (
+    obj !== null &&
+    typeof obj === 'object' &&
+    ('link' in obj || 'title' in obj || 'altText' in obj)
+  );
+}
+
+/**
+ * Type guard to check if an object has SEO fields
+ */
+export function hasContentfulSEOFields(obj: unknown): obj is ContentfulPageSEO {
+  return (
+    obj !== null &&
+    typeof obj === 'object' &&
+    ('title' in obj || 'seoTitle' in obj || 'seoDescription' in obj || 'description' in obj || 'openGraphImage' in obj)
+  );
+}
+
+/**
+ * Safely extracts image URL from Contentful image object
+ */
+export function extractImageUrl(image: unknown, baseUrl: string): string | undefined {
+  if (!isContentfulImage(image)) return undefined;
+  
+  if (!image.link || typeof image.link !== 'string') return undefined;
+  
+  return image.link.startsWith('http') ? image.link : `${baseUrl}${image.link}`;
+}
+
+/**
+ * Safely extracts image alt text from Contentful image object
+ */
+export function extractImageAlt(image: unknown, fallback: string): string {
+  if (!isContentfulImage(image)) return fallback;
+  
+  if (image.altText && typeof image.altText === 'string') {
+    return image.altText;
+  }
+  
+  if (image.title && typeof image.title === 'string') {
+    return image.title;
+  }
+  
+  return fallback;
+}
+
+/**
+ * Safely extracts Open Graph image data from Contentful page object
+ */
+export function extractOpenGraphImage(
+  page: unknown,
+  baseUrl: string,
+  fallbackTitle: string
+): OpenGraphImageResult | undefined {
+  if (!hasContentfulSEOFields(page)) return undefined;
+  
+  const image = page.openGraphImage;
+  if (!isContentfulImage(image)) return undefined;
+  
+  const url = extractImageUrl(image, baseUrl);
+  if (!url) return undefined;
+  
+  const result: OpenGraphImageResult = {
+    url,
+    width: 1200,
+    height: 630
+  };
+  
+  const title = extractImageAlt(image, fallbackTitle);
+  if (title !== fallbackTitle) {
+    result.title = title;
+  }
+  
+  return result;
+}
+
+/**
+ * Safely extracts SEO title from Contentful page object
+ */
+export function extractSEOTitle(page: unknown, fallback: string): string {
+  if (!hasContentfulSEOFields(page)) return fallback;
+  
+  if (page.seoTitle && typeof page.seoTitle === 'string') {
+    return page.seoTitle;
+  }
+  
+  if (page.title && typeof page.title === 'string') {
+    return page.title;
+  }
+  
+  return fallback;
+}
+
+/**
+ * Safely extracts SEO description from Contentful page object
+ */
+export function extractSEODescription(page: unknown, fallback: string): string {
+  if (!hasContentfulSEOFields(page)) return fallback;
+  
+  if (page.seoDescription && typeof page.seoDescription === 'string') {
+    return page.seoDescription;
+  }
+  
+  if (page.description && typeof page.description === 'string') {
+    return page.description;
+  }
+  
+  return fallback;
+}

--- a/src/types/contentful/Page.ts
+++ b/src/types/contentful/Page.ts
@@ -29,6 +29,9 @@ export const PageSchema = z.object({
     })
     .optional(),
   footer: z.lazy(() => require('./Footer').FooterSchema).optional(),
+  openGraphImage: z.lazy(() => require('./Image').ImageSchema).optional(),
+  seoTitle: z.string().optional(),
+  seoDescription: z.string().optional(),
   __typename: z.string().optional()
 });
 
@@ -57,6 +60,9 @@ export const PageWithRefsSchema = z.object({
       __typename: z.string()
     })
     .optional(),
+  openGraphImage: z.lazy(() => require('./Image').ImageSchema).optional(),
+  seoTitle: z.string().optional(),
+  seoDescription: z.string().optional(),
   __typename: z.string().optional()
 });
 


### PR DESCRIPTION
# Overview

This PR implements comprehensive SEO metadata generation that dynamically sources data from **Contentful Page** components, ensuring all **Vercel SEO checks** are covered and **Open Graph images** are properly mapped to Contentful Image fields.

---

## Key Features

### Dynamic SEO Metadata
- **SEO Title:**  
  `page.seoTitle` → fallback to `page.title` → fallback to site default
- **SEO Description:**  
  `page.seoDescription` → fallback to `page.description` → fallback to site default
- **Open Graph Image:**  
  Dynamically reads from `page.openGraphImage.link` field (**Contentful Image** type)

### Complete OpenGraph & Twitter Cards
- `og:url` – Canonical page URLs  
- `og:image` – Mapped to Contentful Image `link` field  
- `og:title` & `og:description` – Dynamic from Page component  
- `og:site_name` & `og:type` – Proper site metadata  
- Twitter card support with `summary_large_image`

### Vercel SEO Compliance
- Title tags  
- Meta descriptions  
- Open Graph images  
- Twitter cards  
- Canonical URLs  
- Viewport meta tag  
- Language attributes  
- Robots meta tag

---

## Technical Implementation

### Files Added/Modified
- **`src/app/[slug]/page.tsx`** – Added `generateMetadata` for dynamic routes  
- **`src/app/page.tsx`** – Enhanced root page metadata with proper image handling  
- **`src/app/layout.tsx`** – Added base SEO metadata (viewport, robots, etc.)  
- **`src/lib/metadata-utils.ts`** – **NEW** Type-safe utility functions for metadata extraction  

### Type Safety & Code Quality
- Resolved all TypeScript/ESLint errors with proper type guards  
- Created robust utility functions for safe metadata extraction  
- Handles both absolute and relative image URLs  
- Proper fallback mechanisms for missing data  

### Image URL Handling
- Correctly maps OG images to Contentful Image `link` field  
- Handles both `http://` URLs and relative paths  
- Prepends `baseUrl` for relative URLs  
- Extracts alt text from `altText` or `title` fields

---

## Testing
- ✅ Build passes successfully  
- ✅ All TypeScript/ESLint errors resolved  
- ✅ Metadata generates correctly for both static and dynamic routes  
- ✅ Ready for social media link preview testing  

---

## Usage
Pages with **Contentful Page** components now automatically generate:
- Dynamic SEO titles and descriptions  
- Open Graph images from the `openGraphImage.link` field  
- Proper canonical URLs  
- Complete social media metadata  

---

## Related
- Addresses **Vercel SEO check** requirements  
- Improves social media sharing with proper OG tags  
- Enhances search engine optimization with dynamic metadata  

> **Note:** PageList SEO enhancement will be addressed in a future PR once Page implementation is verified working.
